### PR TITLE
Updated doc-ver-api to 0.0.11.

### DIFF
--- a/helm/doc-ver/Chart.yaml
+++ b/helm/doc-ver/Chart.yaml
@@ -1,10 +1,10 @@
 name: doc-ver
 apiVersion: v2
-version: 0.4.5
+version: 0.4.6
 dependencies:
 - name: doc-ver-api
   repository: https://helm.microblink.com/charts
-  version: 0.0.10
+  version: 0.0.11
   condition: doc-ver-api.enabled
 - name: visual-anomaly
   repository: https://helm.microblink.com/charts

--- a/helm/doc-ver/README.md
+++ b/helm/doc-ver/README.md
@@ -1,6 +1,6 @@
 # doc-ver
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square)
 
 ## Requirements
 
@@ -9,7 +9,7 @@
 | https://charts.bitnami.com/bitnami | postgresql | 13.2.27 |
 | https://helm.microblink.com/charts | anomdet-intermediary | 0.0.10 |
 | https://helm.microblink.com/charts | bundle-visual-anomaly-core-versions | 0.4.13 |
-| https://helm.microblink.com/charts | doc-ver-api | 0.0.10 |
+| https://helm.microblink.com/charts | doc-ver-api | 0.0.11 |
 | https://helm.microblink.com/charts | embedding-store | 0.3.12 |
 | https://helm.microblink.com/charts | mlp-local-storage | 2.1.0 |
 | https://helm.microblink.com/charts | visual-anomaly | 0.0.10 |


### PR DESCRIPTION
Updated `doc-ver-api` to `0.0.11`.
Updated `doc-ver-api` HPA api group version from `v2beta2` to `v2`.