### PR TITLE
Increased pgvector health check retries number.

### DIFF
--- a/docker-compose/base/embedding-store/docker-compose.yaml
+++ b/docker-compose/base/embedding-store/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
     healthcheck:
       test: [ 'CMD', 'pg_isready', '-q', '-U', 'postgres' ]
       interval: 15s
-      retries: 5
+      retries: 10
       timeout: 10s
     environment:
       - POSTGRES_USER=postgres


### PR DESCRIPTION
Increased pgvector health check retries number. Starting the database after it was populated can take a bit longer than the previously set timeout.