### PR TITLE
Fix doc-ver-runner docker-compose env variables. 

### DIFF
--- a/docker-compose/template/conf/doc-ver-runner/.env
+++ b/docker-compose/template/conf/doc-ver-runner/.env
@@ -3,6 +3,7 @@ LIMITS_MEM=4Gb
 RESERVATIONS_CPUS=0.5
 RESERVATIONS_MEM=512Mb
 VA_URL="visual-anomaly:8080"
+REPLICAS=1
 # Following vars are set by running init.sh
 #APPLICATION_ID=''
 #LICENSE_KEY=''


### PR DESCRIPTION
Added missing REPLICAS env variable.