### PR TITLE
fix helm writable run volume for single image startup

### DIFF
--- a/helm/doc-ver/README.md
+++ b/helm/doc-ver/README.md
@@ -90,6 +90,7 @@ helm install my-release -f <path to values file you want to use to configure the
 | docVer.terminationGracePeriodSeconds | int | `30` | graceful shutdown timeout |
 | docVer.tolerations | list | `[]` | deployment tolerations |
 | docVer.topologySpreadConstraints | list | `[]` | deployment topologySpreadConstraints |
+| docVer.volumes.run.sizeLimit | string | `""` |  |
 | docVer.volumes.tmp | object | `{"sizeLimit":""}` | size limits for writable emptyDir volumes (optional, e.g. "1Gi") |
 | docVer.volumes.varLog.sizeLimit | string | `""` |  |
 | docVer.volumes.varTmp.sizeLimit | string | `""` |  |

--- a/helm/doc-ver/templates/single-image-deployment.yaml
+++ b/helm/doc-ver/templates/single-image-deployment.yaml
@@ -39,6 +39,8 @@ spec:
               containerPort: {{ .Values.docVer.service.port }}
               protocol: TCP
           volumeMounts:
+            - name: run
+              mountPath: /run
             - name: tmp
               mountPath: /tmp
             - name: var-tmp
@@ -115,6 +117,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: run
+          emptyDir:
+            {{- with .Values.docVer.volumes.run.sizeLimit }}
+            sizeLimit: {{ . }}
+            {{- end }}
         - name: tmp
           emptyDir:
             {{- with .Values.docVer.volumes.tmp.sizeLimit }}

--- a/helm/doc-ver/values.yaml
+++ b/helm/doc-ver/values.yaml
@@ -126,6 +126,8 @@ docVer:
       type: RuntimeDefault
   volumes:
     # -- size limits for writable emptyDir volumes (optional, e.g. "1Gi")
+    run:
+      sizeLimit: ""
     tmp:
       sizeLimit: ""
     varTmp:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configurable `run` volume to deployment with optional size limit setting

* **Documentation**
  * Updated configuration documentation for the new volume option

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/microblink/doc-ver-ops/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->