### PR TITLE
3.22.0 release

### DIFF
--- a/helm/doc-ver/Chart.yaml
+++ b/helm/doc-ver/Chart.yaml
@@ -1,6 +1,6 @@
 name: doc-ver
 apiVersion: v2
-version: 1.0.5
-appVersion: 3.21.1
+version: 1.0.6
+appVersion: 3.22.0
 description: Single-image Document Verification deployment
 type: application

--- a/helm/doc-ver/README.md
+++ b/helm/doc-ver/README.md
@@ -1,6 +1,6 @@
 # doc-ver
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.21.1](https://img.shields.io/badge/AppVersion-3.21.1-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.22.0](https://img.shields.io/badge/AppVersion-3.22.0-informational?style=flat-square)
 
 Single-image Document Verification deployment
 
@@ -52,7 +52,7 @@ helm install my-release -f <path to values file you want to use to configure the
 | docVer.image.pullPolicy | string | `"IfNotPresent"` | deployment docker image pull policy |
 | docVer.image.pullSecrets | list | `[]` | deployment docker image pull secrets |
 | docVer.image.repository | string | `"us-docker.pkg.dev/document-verification-public/verify-public/single-image"` | deployment docker image repository |
-| docVer.image.tag | string | `"3.21.1"` | deployment docker image tag, if not set, version will be used as tag |
+| docVer.image.tag | string | `"3.22.0"` | deployment docker image tag, if not set, version will be used as tag |
 | docVer.ingress.annotations | object | `{}` |  |
 | docVer.ingress.className | string | `""` |  |
 | docVer.ingress.enabled | bool | `false` | enable if you want to expose the service |

--- a/helm/doc-ver/values.yaml
+++ b/helm/doc-ver/values.yaml
@@ -24,7 +24,7 @@ docVer:
     # -- deployment docker image pull policy
     pullPolicy: IfNotPresent
     # -- deployment docker image tag, if not set, version will be used as tag
-    tag: "3.21.1"
+    tag: "3.22.0"
     # -- deployment docker image pull secrets
     pullSecrets: []
   service:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version from 1.0.5 to 1.0.6
  * Updated application version from 3.21.1 to 3.22.0
  * Updated container image configuration to use the new application version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->